### PR TITLE
Replace deprecated code

### DIFF
--- a/Wearable/src/main/java/com/example/android/wearable/watchface/DigitalWatchFaceService.java
+++ b/Wearable/src/main/java/com/example/android/wearable/watchface/DigitalWatchFaceService.java
@@ -28,6 +28,7 @@ import android.graphics.Typeface;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Message;
+import android.support.v4.content.ContextCompat;
 import android.support.wearable.watchface.CanvasWatchFaceService;
 import android.support.wearable.watchface.WatchFaceService;
 import android.support.wearable.watchface.WatchFaceStyle;

--- a/Wearable/src/main/java/com/example/android/wearable/watchface/DigitalWatchFaceService.java
+++ b/Wearable/src/main/java/com/example/android/wearable/watchface/DigitalWatchFaceService.java
@@ -200,12 +200,12 @@ public class DigitalWatchFaceService extends CanvasWatchFaceService {
 
             mBackgroundPaint = new Paint();
             mBackgroundPaint.setColor(mInteractiveBackgroundColor);
-            mDatePaint = createTextPaint(resources.getColor(R.color.digital_date));
+            mDatePaint = createTextPaint(ContextCompat.getColor(getApplicationContext(), R.color.digital_date));
             mHourPaint = createTextPaint(mInteractiveHourDigitsColor, BOLD_TYPEFACE);
             mMinutePaint = createTextPaint(mInteractiveMinuteDigitsColor);
             mSecondPaint = createTextPaint(mInteractiveSecondDigitsColor);
-            mAmPmPaint = createTextPaint(resources.getColor(R.color.digital_am_pm));
-            mColonPaint = createTextPaint(resources.getColor(R.color.digital_colons));
+            mAmPmPaint = createTextPaint(ContextCompat.getColor(getApplicationContext(),R.color.digital_am_pm));
+            mColonPaint = createTextPaint(ContextCompat.getColor(getApplicationContext(),R.color.digital_colons));
 
             mCalendar = Calendar.getInstance();
             mDate = new Date();


### PR DESCRIPTION
resources.getColor() is deprecated on API 23+  
replaced it with ContextCompat.getColor()
